### PR TITLE
Refresh FPM service when a new FPM pool is created

### DIFF
--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -34,6 +34,9 @@ define php::fpm::pool(
     default => $socket
   }
 
+  # Set config
+
+  $fpm_pool_config_dir = "${php::config::configdir}/${version}/pool.d"
   $pool_name = join(split($name, '[.] '), '-')
 
   # Set up PHP-FPM pool

--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -22,9 +22,6 @@ define php::fpm::pool(
 ) {
   require php::config
 
-  # Set some nginx params to ensure that fastcgi actually works
-  include php::fpm::fastcgi
-
   $repo_dir = $dir ? {
     undef   => "${boxen::config::srcdir}/${name}",
     default => $dir

--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -1,7 +1,7 @@
-# Set up a PHP FPM pool listening on a socket
+# Set up a PHP-FPM pool listening on a socket
 #
-# Automatically ensures that php version is installed via phpenv & php-build
-# and that PHP FPM is installed as a service for that version of PHP
+# Automatically ensures that the version of PHP is installed and
+# PHP-FPM is installed as a service for that version
 #
 # Usage:
 #
@@ -22,6 +22,8 @@ define php::fpm::pool(
 ) {
   require php::config
 
+  # Set defaults
+
   $repo_dir = $dir ? {
     undef   => "${boxen::config::srcdir}/${name}",
     default => $dir
@@ -34,8 +36,11 @@ define php::fpm::pool(
 
   $pool_name = join(split($name, '[.] '), '-')
 
+  # Set up PHP-FPM pool
+
   if $ensure == present {
-    # Requires php fpm version eg. php::fpm::5-4-10
+    # Ensure that the php fpm service for this php version is installed
+    # eg. php::fpm::5-4-10
     include join(['php', 'fpm', join(split($version, '[.]'), '-')], '::')
 
     # Create a pool config file

--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -50,6 +50,7 @@ define php::fpm::pool(
     file { "${php::config::configdir}/${version}/pool.d/${pool_name}.conf":
       content => template('php/php-fpm-pool.conf.erb'),
       require => File[$fpm_pool_config_dir],
+      notify  => Service["dev.php-fpm.${version}"],
     }
   }
 }

--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -39,11 +39,12 @@ define php::fpm::pool(
 
   if $ensure == present {
     # Requires php fpm version eg. php::fpm::5-4-10
-    require join(['php', 'fpm', join(split($version, '[.]'), '-')], '::')
+    include join(['php', 'fpm', join(split($version, '[.]'), '-')], '::')
 
     # Create a pool config file
     file { "${php::config::configdir}/${version}/pool.d/${pool_name}.conf":
       content => template('php/php-fpm-pool.conf.erb'),
+      require => File[$fpm_pool_config_dir],
     }
   }
 }

--- a/manifests/fpm/service.pp
+++ b/manifests/fpm/service.pp
@@ -12,6 +12,9 @@ define php::fpm::service(
 ) {
   require php::config
 
+  # Set some nginx params to ensure that fastcgi actually works
+  include php::fpm::fastcgi
+
   # Config file locations
   $fpm_config = "${php::config::configdir}/${version}/php-fpm.conf"
 

--- a/manifests/fpm/service.pp
+++ b/manifests/fpm/service.pp
@@ -13,6 +13,7 @@ define php::fpm::service(
   require php::config
 
   # Set some nginx params to ensure that fastcgi actually works
+  include nginx::config
   include php::fpm::fastcgi
 
   # Config file locations
@@ -38,8 +39,9 @@ define php::fpm::service(
     }
 
     service { "dev.php-fpm.${version}":
-      ensure  => running,
-      subscribe  => File["/Library/LaunchDaemons/dev.php-fpm.${version}.plist"]
+      ensure    => running,
+      subscribe => File["/Library/LaunchDaemons/dev.php-fpm.${version}.plist"],
+      require   => File["${nginx::config::configdir}/fastcgi_params"],
     }
 
   } else {


### PR DESCRIPTION
Rather optimistic that this resolves #1 and #14.

I've changed the dependency tree so that the `php::fpm::pool` class includes the `php::fpm` class which defines the service, rather than requiring it. This then allows the applicable fpm service to be notified by a change to a pool config file.
