### PR TITLE
allow for customization of php-fpm-pool configuration

### DIFF
--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -19,6 +19,7 @@ define php::fpm::pool(
   $min_spare_servers = 1,
   $max_spare_servers = 1,
   $ensure            = present,
+  $fpm_pool_config   = 'php/php-fpm-pool.conf.erb',
 ) {
   require php::config
 
@@ -47,8 +48,8 @@ define php::fpm::pool(
     include join(['php', 'fpm', join(split($version, '[.]'), '-')], '::')
 
     # Create a pool config file
-    file { "${php::config::configdir}/${version}/pool.d/${pool_name}.conf":
-      content => template('php/php-fpm-pool.conf.erb'),
+    file { "${fpm_pool_config_dir}/${pool_name}.conf":
+      content => template($fpm_pool_config),
       require => File[$fpm_pool_config_dir],
       notify  => Service["dev.php-fpm.${version}"],
     }

--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -19,7 +19,7 @@ define php::fpm::pool(
   $min_spare_servers = 1,
   $max_spare_servers = 1,
   $ensure            = present,
-  $fpm_pool_config   = 'php/php-fpm-pool.conf.erb',
+  $fpm_pool          = 'php/php-fpm-pool.conf.erb',
 ) {
   require php::config
 
@@ -49,7 +49,7 @@ define php::fpm::pool(
 
     # Create a pool config file
     file { "${fpm_pool_config_dir}/${pool_name}.conf":
-      content => template($fpm_pool_config),
+      content => template($fpm_pool),
       require => File[$fpm_pool_config_dir],
       notify  => Service["dev.php-fpm.${version}"],
     }

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -63,6 +63,12 @@
 #     source =>
 #       Repo to clone project from. REQUIRED. Supports shorthand <user>/<repo>.
 #
+#     server_name =>
+#       The hostname to use when accessing the application.
+#
+#     fpm_pool_config =>
+#       Location of custom FPM pool configuration file template.
+#
 
 define php::project(
   $source,
@@ -84,6 +90,7 @@ define php::project(
   $ruby          = undef,
   $php           = undef,
   $server_name   = "${name}.dev",
+  $fpm_pool_config   = undef,
 ) {
   include boxen::config
 
@@ -199,6 +206,12 @@ define php::project(
       version => $php,
       socket  => "${boxen::config::socketdir}/${name}",
       require => File["${nginx::config::sitesdir}/${name}.conf"],
+    }
+
+    if $fpm_pool_config {
+      Php::Fpm::Pool["${name}-${php}"] {
+        fpm_pool_config => $fpm_pool_config
+      }
     }
   }
 

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -66,7 +66,7 @@
 #     server_name =>
 #       The hostname to use when accessing the application.
 #
-#     fpm_pool_config =>
+#     fpm_pool =>
 #       Location of custom FPM pool configuration file template.
 #
 
@@ -90,7 +90,7 @@ define php::project(
   $ruby          = undef,
   $php           = undef,
   $server_name   = "${name}.dev",
-  $fpm_pool_config   = undef,
+  $fpm_pool      = undef,
 ) {
   include boxen::config
 
@@ -208,9 +208,9 @@ define php::project(
       require => File["${nginx::config::sitesdir}/${name}.conf"],
     }
 
-    if $fpm_pool_config {
+    if $fpm_pool {
       Php::Fpm::Pool["${name}-${php}"] {
-        fpm_pool_config => $fpm_pool_config
+        fpm_pool => $fpm_pool
       }
     }
   }

--- a/templates/nginx/nginx.conf.erb
+++ b/templates/nginx/nginx.conf.erb
@@ -10,7 +10,7 @@ server {
   access_log <%= scope.lookupvar "nginx::config::logdir" %>/<%= name %>.access.log main;
   listen 80;
   root <%= repo_dir %>/www;
-  server_name <%= name %>.dev;
+  server_name <%= server_name %>;
 
   client_max_body_size 50M;
 


### PR DESCRIPTION
Hi Matt,

I made a couple minor changes.  One is consuming the `$server_name` passed to `php::project`.  The other is allowing for providing a custom php-fpm-pool configuration template.  I needed this to set a `php_admin_value` for one of my apps.

-AA
