### PR TITLE
use zlib 1.2.8

### DIFF
--- a/files/brews/zlib.rb
+++ b/files/brews/zlib.rb
@@ -2,16 +2,14 @@ require 'formula'
 
 class Zlibphp < Formula
   homepage 'http://www.zlib.net/'
-  url 'http://zlib.net/zlib-1.2.7.tar.gz'
-  sha1 '4aa358a95d1e5774603e6fa149c926a80df43559'
+  url 'http://zlib.net/zlib-1.2.8.tar.gz'
+  sha1 'a4d316c404ff54ca545ea71a27af7dbc29817088'
 
   keg_only :provided_by_osx
 
-  version '1.2.7-boxen1'
+  version '1.2.8-boxen1'
 
   option :universal
-
-  def patches; DATA; end
 
   def install
     ENV.universal_binary if build.universal?
@@ -20,18 +18,3 @@ class Zlibphp < Formula
   end
 end
 
-# /usr/bin/libtool is no use to CLT-less rigs
-__END__
-diff --git a/configure b/configure
-index 36c7d8e..0c97d7b 100755
---- a/configure
-+++ b/configure
-@@ -231,7 +231,7 @@ if test "$gcc" -eq 1 && ($cc -c $cflags $test.c) >> configure.log 2>&1; then
-              SHAREDLIBV=libz.$VER$shared_ext
-              SHAREDLIBM=libz.$VER1$shared_ext
-              LDSHARED=${LDSHARED-"$cc -dynamiclib -install_name $libdir/$SHAREDLIBM -compatibility_version $VER1 -current_version $VER3"}
--             AR="/usr/bin/libtool"
-+             AR="libtool"
-              ARFLAGS="-o" ;;
-   *)             LDSHARED=${LDSHARED-"$cc -shared"} ;;
-   esac

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,7 +94,7 @@ class php {
   }
 
   package { 'boxen/brews/zlibphp':
-    ensure => '1.2.7-boxen1',
+    ensure => '1.2.8-boxen1',
   }
 
   # Set up phpenv


### PR DESCRIPTION
zlib 1.2.7 is no longer available at the download location specified.  Also, 1.2.8 fixes the issue being corrected with the patch, so that's no longer needed either.

Still need to destroy existing versions of PHP and re-install.

-AA
