### PR TITLE
Redis extension for PHP

### DIFF
--- a/manifests/extension/redis.pp
+++ b/manifests/extension/redis.pp
@@ -1,0 +1,53 @@
+# Installs the redis php extension for a specific version of php.
+#
+# Usage:
+#
+#     php::extension::xdebug { 'redis for 5.4.10':
+#       version   => '2.2.3'
+#       php       => '5.4.10',
+#     }
+#
+define php::extension::redis(
+  $php,
+  $version = '2.2.3'
+) {
+  require redis
+
+  require php::config
+  # Require php version eg. php::5_4_10
+  # This will compile, install and set up config dirs if not present
+  require join(['php', join(split($php, '[.]'), '_')], '::')
+
+  $extension = 'redis'
+
+  # Final module install path
+  $module_path = "${php::config::root}/versions/${php}/modules/${extension}.so"
+
+  # Clone the source repository
+  repository { "${php::config::extensioncachedir}/redis":
+    source => 'nicolasff/phpredis'
+  }
+
+  # Build & install the extension
+  php_extension { $name:
+    provider       => 'git',
+
+    extension      => $extension,
+    version        => $version,
+
+    homebrew_path  => $boxen::config::homebrewdir,
+    phpenv_root    => $php::config::root,
+    php_version    => $php,
+
+    cache_dir      => $php::config::extensioncachedir,
+    require        => Repository["${php::config::extensioncachedir}/zmq"],
+  }
+
+  # Add config file once extension is installed
+
+  file { "${php::config::configdir}/${php}/conf.d/${extension}.ini":
+    content => template('php/extensions/generic.ini.erb'),
+    require => Php_extension[$name],
+  }
+
+}

--- a/manifests/extension/redis.pp
+++ b/manifests/extension/redis.pp
@@ -2,7 +2,7 @@
 #
 # Usage:
 #
-#     php::extension::xdebug { 'redis for 5.4.10':
+#     php::extension::redis { 'redis for 5.4.10':
 #       version   => '2.2.3'
 #       php       => '5.4.10',
 #     }

--- a/manifests/extension/redis.pp
+++ b/manifests/extension/redis.pp
@@ -40,7 +40,7 @@ define php::extension::redis(
     php_version    => $php,
 
     cache_dir      => $php::config::extensioncachedir,
-    require        => Repository["${php::config::extensioncachedir}/zmq"],
+    require        => Repository["${php::config::extensioncachedir}/redis"],
   }
 
   # Add config file once extension is installed


### PR DESCRIPTION
Allow to integrate the phpredis extension.

> The phpredis extension provides an API for communicating with the Redis key-value store. It is released under the PHP License, version 3.01. This code has been developed and maintained by Owlient from November 2009 to March 2011

[https://github.com/nicolasff/phpredis](https://github.com/nicolasff/phpredis)
