### PR TITLE
add posibility to pass the config template to use for apc/xdebug

### DIFF
--- a/manifests/extension/apc.pp
+++ b/manifests/extension/apc.pp
@@ -9,7 +9,8 @@
 #
 define php::extension::apc(
   $php,
-  $version = '3.1.13'
+  $version = '3.1.13',
+  $config_template = "php/extensions/apc.ini.erb"
 ) {
   require php::config
   # Require php version eg. php::5_4_10
@@ -37,7 +38,7 @@ define php::extension::apc(
   # Add config file once extension is installed
 
   file { "${php::config::configdir}/${php}/conf.d/${extension}.ini":
-    content => template("php/extensions/${extension}.ini.erb"),
+    content => template($config_template),
     require => Php_extension[$name],
   }
 

--- a/manifests/extension/xdebug.pp
+++ b/manifests/extension/xdebug.pp
@@ -9,7 +9,8 @@
 #
 define php::extension::xdebug(
   $php,
-  $version = '2.2.1'
+  $version = '2.2.1',
+  $config_template = "php/extensions/xdebug.ini.erb"
 ) {
   require php::config
   # Require php version eg. php::5_4_10
@@ -37,7 +38,7 @@ define php::extension::xdebug(
   # Add config file once extension is installed
 
   file { "${php::config::configdir}/${php}/conf.d/${extension}.ini":
-    content => template("php/extensions/${extension}.ini.erb"),
+    content => template($config_template),
     require => Php_extension[$name],
   }
 


### PR DESCRIPTION
this should help a lot using own template here, since those are the most reconfigured one. Xdebug, usually autostart can let you go nuts, apc shz_size is also very app dependend.

I think thats pretty much a must have

I did avoid to have configureable vars for those settings to yet let the people do there whole template by themselfs, before you need to cover every bit by a template var
