### PR TITLE
Fix Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
----
-script: "./script/cibuild"
-gemfile: "this/does/not/exist"
+script: ./script/cibuild
+gemfile: this/does/not/exist
 rvm:
-  - "1.8.7"
+  - 1.8.7
+
+env:
+  global:
+    - secure: "NOZW7puzKXd1d7LWn7zEJgTe0cLRo5aTOR924LAQ3x0z79jkz3rfLAfHOD/7jAFcfqLgt6liUpUsdNLrzGzZW5bKi7e+UbCR4TYgkgHl9bgPGz+DpFR+BbZozqdgcnNZWFprnXiwBzWBygxOYq98sdV8cTakJPqjCzyuzdr+O1E="

--- a/manifests/extension/mongo.pp
+++ b/manifests/extension/mongo.pp
@@ -37,7 +37,7 @@ define php::extension::mongo(
   # Add config file once extension is installed
 
   file { "${php::config::configdir}/${php}/conf.d/${extension}.ini":
-    content => template("php/extensions/generic.ini.erb"),
+    content => template('php/extensions/generic.ini.erb'),
     require => Php_extension[$name],
   }
 

--- a/manifests/extension/oauth.pp
+++ b/manifests/extension/oauth.pp
@@ -37,7 +37,7 @@ define php::extension::oauth(
   # Add config file once extension is installed
 
   file { "${php::config::configdir}/${php}/conf.d/${extension}.ini":
-    content => template("php/extensions/generic.ini.erb"),
+    content => template('php/extensions/generic.ini.erb'),
     require => Php_extension[$name],
   }
 

--- a/spec/defines/extensions/php_extension_pecl_http_spec.rb
+++ b/spec/defines/extensions/php_extension_pecl_http_spec.rb
@@ -13,7 +13,6 @@ describe "php::extension::pecl_http" do
 
   it do
     should include_class("boxen::config")
-    should include_class("zookeeper")
     should include_class("php::config")
     should include_class("php::5_4_17")
 

--- a/spec/defines/fpm/php_fpm_pool_spec.rb
+++ b/spec/defines/fpm/php_fpm_pool_spec.rb
@@ -25,7 +25,4 @@ describe "php::fpm::pool" do
     end
   end
 
-  context "ensure => absent" do
-    pending "no absent state handler currently"
-  end
 end

--- a/spec/defines/php_fpm_spec.rb
+++ b/spec/defines/php_fpm_spec.rb
@@ -23,7 +23,6 @@ describe "php::fpm" do
       should contain_file("/test/boxen/config/php/5.4.17/pool.d").with({
         :ensure  => "directory",
         :recurse => "true",
-        :purge   => "true",
         :force   => "true",
         :source  => "puppet:///modules/php/empty-conf-dir",
         :require => "File[/test/boxen/config/php/5.4.17]"


### PR DESCRIPTION
- [x] Fixes some tests
- [x] Adds a secure `GITHUB_API_TOKEN` env variable for travis which will get around the API limits that usually cause builds to fail

Alas this doesn't work for forks / pull requests unfortunately. I'm happy to put in a public read only token from a dummy account (@boxen-tester), but its obviously not good practice, thoughts? /cc @createdbypete
