### PR TITLE
Add PHP 5.3.28

### DIFF
--- a/manifests/5_3_28.pp
+++ b/manifests/5_3_28.pp
@@ -1,0 +1,9 @@
+# Installs php 5.3.28
+#
+# Usage:
+#
+#     include php::5_3_28
+#
+class php::5_3_28 {
+  php::version { '5.3.28': }
+}

--- a/manifests/fpm/5_3_28.pp
+++ b/manifests/fpm/5_3_28.pp
@@ -1,0 +1,10 @@
+# Launches a PHP FPM service running PHP 5.3.28
+# Installs PHP 5.3.28 if it doesn't already exist
+#
+# Usage:
+#
+#     include php::fpm::5_3_28
+#
+class php::fpm::5_3_28 {
+  php::fpm { '5.3.28': }
+}

--- a/spec/classes/fpm/php_fpm_5_3_27_spec.rb
+++ b/spec/classes/fpm/php_fpm_5_3_27_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe "php::fpm::5_3_27" do
+  let(:facts) { default_test_facts }
+
+  it do
+    should contain_php__fpm("5.3.27")
+  end
+end

--- a/spec/classes/fpm/php_fpm_5_3_28_spec.rb
+++ b/spec/classes/fpm/php_fpm_5_3_28_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe "php::fpm::5_3_28" do
+  let(:facts) { default_test_facts }
+
+  it do
+    should contain_php__fpm("5.3.28")
+  end
+end

--- a/spec/classes/php_5_3_28_spec.rb
+++ b/spec/classes/php_5_3_28_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe "php::5_3_28" do
+  let(:facts) { default_test_facts }
+
+  it do
+    should contain_php__version("5.3.28")
+  end
+end


### PR DESCRIPTION
Adds PHP `5.3.28`, with FPM and specs. Also adds missing `5.3.27` fpm spec.

Will rebase once #30 is pulled in so that travis can run the specs.
