### PR TITLE
Fix Autoconf 2.13 sandboxing

### DIFF
--- a/files/brews/autoconf213.rb
+++ b/files/brews/autoconf213.rb
@@ -6,6 +6,8 @@ class Autoconf213 < Formula
   mirror 'http://ftp.gnu.org/gnu/autoconf/autoconf-2.13.tar.gz'
   sha1 'e4826c8bd85325067818f19b2b2ad2b625da66fc'
 
+  keg_only "Sandboxed for PHP installations"
+
   version '2.13-boxen1'
 
   def install
@@ -13,7 +15,7 @@ class Autoconf213 < Formula
                           "--disable-dependency-tracking",
                           "--program-suffix=213",
                           "--prefix=#{prefix}",
-                          "--infodir=#{info}",
+                          "--infodir=#{info}/autoconf213",
                           "--datadir=#{share}/autoconf213"
     system "make install"
   end

--- a/files/brews/autoconf213.rb
+++ b/files/brews/autoconf213.rb
@@ -6,8 +6,6 @@ class Autoconf213 < Formula
   mirror 'http://ftp.gnu.org/gnu/autoconf/autoconf-2.13.tar.gz'
   sha1 'e4826c8bd85325067818f19b2b2ad2b625da66fc'
 
-  keg_only "Sandboxed for PHP installations"
-
   version '2.13-boxen1'
 
   def install

--- a/lib/puppet/provider/php_extension/pecl.rb
+++ b/lib/puppet/provider/php_extension/pecl.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:php_extension).provide(:pecl) do
   include Puppet::Util::Execution
   desc "Provides PHP extensions compiled from their pecl source code"
 
-  defaultfor :source => :pecl
+  defaultfor :operatingsystem => :darwin
 
   # Build and install our PHP extension
   def create

--- a/lib/puppet/type/php_extension.rb
+++ b/lib/puppet/type/php_extension.rb
@@ -51,10 +51,6 @@ Puppet::Type.newtype(:php_extension) do
     defaultto ''
   end
 
-  newparam(:source) do
-    defaultto :pecl
-  end
-
   # Some PECL modules have a different module layout and the php extension
   # source in not in the root directory (e.g. xhprof)
   newparam(:extension_dir) do

--- a/manifests/extension/ssh2.pp
+++ b/manifests/extension/ssh2.pp
@@ -1,0 +1,52 @@
+# Installs a php extension for a specific version of php.
+#
+# Usage:
+#
+#     php::extension::ssh2 { 'ssh2 for 5.4.10':
+#       version   => '0.12'
+#       php       => '5.4.10',
+#     }
+#
+define php::extension::ssh2(
+  $php,
+  $version = '0.12'
+) {
+  include boxen::config
+  require ssh2::lib
+
+  require php::config
+  # Require php version eg. php::5_4_10
+  # This will compile, install and set up config dirs if not present
+  require join(['php', join(split($php, '[.]'), '_')], '::')
+
+  $extension = 'ssh2'
+  $package_name = "ssh2-${version}"
+  $url = "http://pecl.php.net/get/ssh2-${version}.tgz"
+
+  # Final module install path
+  $module_path = "${php::config::root}/versions/${php}/modules/${extension}.so"
+
+  # Additional options
+  $configure_params = "--with-libssh2=${boxen::config::homebrewdir}/opt/libssh2"
+
+  php_extension { $name:
+    extension        => $extension,
+    version          => $version,
+    package_name     => $package_name,
+    package_url      => $url,
+    homebrew_path    => $boxen::config::homebrewdir,
+    phpenv_root      => $php::config::root,
+    php_version      => $php,
+    cache_dir        => $php::config::extensioncachedir,
+    provider         => pecl,
+    configure_params => $configure_params,
+  }
+
+  # Add config file once extension is installed
+
+  file { "${php::config::configdir}/${php}/conf.d/${extension}.ini":
+    content => template('php/extensions/generic.ini.erb'),
+    require => Php_extension[$name],
+  }
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,6 +78,7 @@ class php {
   # Need autoconf version less than 2.59 for php 5.3 (ewwwww)
 
   homebrew::formula { 'autoconf213':
+    source => 'puppet:///modules/php/brews/autoconf213.rb',
     before => Package['boxen/brews/autoconf213'],
   }
 

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -203,9 +203,10 @@ define php::project(
 
     # Spin up a PHP-FPM pool for this project, listening on an Nginx socket
     php::fpm::pool { "${name}-${php}":
-      version     => $php,
-      socket_path => "${boxen::config::socketdir}/${name}",
-      require     => File["${nginx::config::sitesdir}/${name}.conf"],
+      version      => $php,
+      socket_path  => "${boxen::config::socketdir}/${name}",
+      require      => File["${nginx::config::sitesdir}/${name}.conf"],
+      max_children => 10,
     }
 
     if $fpm_pool {

--- a/spec/defines/extensions/php_extension_ssh2_spec.rb
+++ b/spec/defines/extensions/php_extension_ssh2_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe "php::extension::ssh2" do
+  let(:pre_condition) { "class ssh2::lib {}" }
+  let(:facts) { default_test_facts }
+  let(:title) { "ssh2 for 5.4.17" }
+  let(:params) do
+    {
+      :php     => "5.4.17",
+      :version => "0.12"
+    }
+  end
+
+  it do
+    should include_class("boxen::config")
+    should include_class("ssh2::lib")
+    should include_class("php::config")
+    should include_class("php::5_4_17")
+
+    should contain_php_extension("ssh2 for 5.4.17").with({
+      :extension        => "ssh2",
+      :version          => "0.12",
+      :package_name     => "ssh2-0.12",
+      :package_url      => "http://pecl.php.net/get/ssh2-0.12.tgz",
+      :homebrew_path    => "/test/boxen/homebrew",
+      :phpenv_root      => "/test/boxen/phpenv",
+      :php_version      => "5.4.17",
+      :cache_dir        => "/test/boxen/data/php/cache/extensions",
+      :provider         => "pecl",
+    })
+
+    should contain_file("/test/boxen/config/php/5.4.17/conf.d/ssh2.ini").with({
+      :content => File.read("spec/fixtures/ssh2.ini"),
+      :require => "Php_extension[ssh2 for 5.4.17]"
+    })
+  end
+end

--- a/spec/fixtures/ssh2.ini
+++ b/spec/fixtures/ssh2.ini
@@ -1,0 +1,1 @@
+extension=/test/boxen/phpenv/versions/5.4.17/modules/ssh2.so


### PR DESCRIPTION
Sandboxing the autoconf package as _keg_only_ means that the `autoconf213` and `autoheader213` binaries aren't symlinked into the Homebrew `bin` folder. This then means the php version provider can't find these for the older versions of PHP and installs fail.
